### PR TITLE
bump jsdom to @^7.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "jsdom"
   ],
   "dependencies": {
-    "jsdom": "^6.5.1"
+    "jsdom": "^7.0.0"
   },
   "license": "MIT"
 }


### PR DESCRIPTION
works fine for me, seems like API used in launcher is not broken.

[changelog](https://github.com/tmpvar/jsdom/blob/master/Changelog.md).
