### PR TITLE
Bump jsdom to ^9.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "karma-jsdom-launcher",
-  "version": "3.0.0",
+  "version": "4.0.0",
   "description": "A Karma plugin. Launcher for jsdom.",
   "main": "index.js",
   "author": "Jonas Amundsen <jonasba@gmail.com>",
@@ -14,7 +14,7 @@
     "jsdom"
   ],
   "dependencies": {
-    "jsdom": "^8.0.0"
+    "jsdom": "^9.0.0"
   },
   "license": "MIT"
 }


### PR DESCRIPTION
Bumping major version of jsdom.

Changelog can be found here: https://github.com/tmpvar/jsdom/blob/master/Changelog.md

There are a bunch of changes since 8.0.0, but I don't think any should affect the launcher. The breaking change that caused the major version bump was the removal of mutation events.
